### PR TITLE
Set server_tokens off in nginx config

### DIFF
--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -24,6 +24,7 @@ http {
   tcp_nodelay on;
   keepalive_timeout 1200;
   types_hash_max_size 2048;
+  server_tokens off;
 
   include /var/vcap/packages/nginx/conf/mime.types;
   default_type application/octet-stream;


### PR DESCRIPTION
This adds to the layer of obscurity (can't hurt) by setting server_tokens off.
http://nginx.org/en/docs/http/ngx_http_core_module.html#server_tokens