### PR TITLE
Inject headers into all responses;  drop content-type injection

### DIFF
--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -111,11 +111,11 @@ http {
       # Security
       ##
 
-      add_header Strict-Transport-Security $sts;
-      add_header X-Frame-Options $frame_options;
-      add_header Content-Type $default_content_type;
-      add_header X-Content-Type-Options $content_type_options;
-      add_header X-XSS-Protection $xss_protection;
+      add_header Strict-Transport-Security $sts always;
+      add_header X-Frame-Options $frame_options always;
+      add_header Content-Type $default_content_type always;
+      add_header X-Content-Type-Options $content_type_options always;
+      add_header X-XSS-Protection $xss_protection always;
 
       fastcgi_param               HTTP_PROXY "";
 

--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -85,9 +85,6 @@ http {
   map $upstream_http_x_frame_options $frame_options {
     '' DENY;
   }
-  map $upstream_http_content_type $default_content_type {
-    '' 'text/plain; charset=utf-8';
-  }
   map $upstream_http_x_content_type_options $content_type_options {
     '' nosniff;
   }
@@ -113,7 +110,6 @@ http {
 
       add_header Strict-Transport-Security $sts always;
       add_header X-Frame-Options $frame_options always;
-      add_header Content-Type $default_content_type always;
       add_header X-Content-Type-Options $content_type_options always;
       add_header X-XSS-Protection $xss_protection always;
 


### PR DESCRIPTION
We should inject headers into all responses regardless of response code.

Injecting a content-type header when one is not provided [caused the acceptance tests to fail](https://ci.fr.cloud.gov/teams/main/pipelines/deploy-cf/jobs/acceptance-tests-staging/builds/75). Removing that recent addition until I can figure out why.