### PR TITLE
Bump header buffer size to allow long URLs.

### DIFF
--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -66,7 +66,7 @@ http {
 
   # connection_pool_size        256;
   # client_header_buffer_size   16k;
-  # large_client_header_buffers 4 32k;
+  large_client_header_buffers 4 16k;
   # request_pool_size       16k;
 
   # Add map for websockets


### PR DESCRIPTION
Workaround for https://github.com/cloudfoundry-incubator/admin-ui/issues/167.