### PR TITLE
SecureProxy should identify itself

### DIFF
--- a/packages/nginx/packaging
+++ b/packages/nginx/packaging
@@ -6,6 +6,9 @@ tar xzvf pcre-8.40.tar.gz
 echo "Extracting nginx..."
 tar xzvf nginx-1.10.3.tar.gz
 
+# make it clear when we respond it's our nginx, and not one further down the chain
+sed -i '' 's/\(Server: \)/\1cloud.gov secureproxy\//' src/http/ngx_http_header_filter_module.c
+
 echo "Building nginx..."
 pushd nginx-1.10.3
   ./configure \

--- a/packages/nginx/packaging
+++ b/packages/nginx/packaging
@@ -6,11 +6,11 @@ tar xzvf pcre-8.40.tar.gz
 echo "Extracting nginx..."
 tar xzvf nginx-1.10.3.tar.gz
 
-# make it clear when we respond it's our nginx, and not one further down the chain
-sed -i '' 's/\(Server: \)/\1cloud.gov secureproxy\//' src/http/ngx_http_header_filter_module.c
-
 echo "Building nginx..."
 pushd nginx-1.10.3
+  # make it clear when we respond it's our nginx, and not one further down the chain
+  sed -i '' 's/\(Server: \)/\1cloud.gov secureproxy\//' src/http/ngx_http_header_filter_module.c
+
   ./configure \
     --prefix=${BOSH_INSTALL_TARGET} \
     --with-pcre=../pcre-8.40


### PR DESCRIPTION
In order to quickly understand where nginx-generated error messages are coming from, as an operator or customer of the cloud.gov platform I want errors from secureproxy to be clearly identified.