### PR TITLE
Swap text/html for application/javascript.

### DIFF
--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -50,7 +50,7 @@ http {
   gzip on;
   gzip_disable "msie6";
   gzip_vary on;
-  gzip_types  text/plain text/css application/x-javascript application/json text/xml application/xml application/xml+rss text/javascript application/rss+xml text/html;
+  gzip_types  text/plain text/css application/x-javascript application/json text/xml application/xml application/xml+rss text/javascript application/rss+xml application/javascript;
 
 
   ##


### PR DESCRIPTION
@sharms pointed out that nginx gzips text/html is always compressed, so adding
it to this list isn't useful:
http://nginx.org/en/docs/http/ngx_http_gzip_module.html

On the other hand @jeremiak found that we *weren't* compressing
application/javascript. x-javascript is now "obsolete".