### PR TITLE
Increase proxied headers maximum size to 16k

### DIFF
--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -195,6 +195,7 @@ http {
       fastcgi_param               HTTP_PROXY "";
 
       proxy_buffering             off;
+      proxy_buffer_size           16k;
       proxy_http_version          1.1;
       proxy_set_header            Upgrade $http_upgrade;
       proxy_set_header            Connection $connection_upgrade;


### PR DESCRIPTION
Currently clients which have large headers may generate '502 Bad Gateway' from NGINX.  Upon further investigation the proxy emits a message:

```
upstream sent too big header while reading response header from upstream
```

Although requests are not buffered, the proxy itself has a buffer in which to read prior to sending.  This buffer is specified by http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size and defaults to 4k.  