### PR TITLE
Adjust buffers to match buffer size.

### DIFF
--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -200,6 +200,7 @@ http {
 
       proxy_buffering             off;
       proxy_buffer_size           16k;
+      proxy_buffers               4 16k;
       proxy_http_version          1.1;
       proxy_set_header            Upgrade $http_upgrade;
       proxy_set_header            Connection $connection_upgrade;


### PR DESCRIPTION
Fixes `"proxy_busy_buffers_size" must be less than the size of all
"proxy_buffers" minus one buffer`.